### PR TITLE
Unidrectional Dragging

### DIFF
--- a/@types/DiagramSchema.ts
+++ b/@types/DiagramSchema.ts
@@ -13,7 +13,7 @@ export type NodeCoordinates = [number, number];
 export type Node<P> = {
   id: string;
   coordinates: NodeCoordinates;
-  disableDrag?: boolean;
+  disableDrag?: string | boolean;
   content?: ReactNode;
   inputs?: Port[];
   outputs?: Port[];

--- a/src/Diagram/DiagramNode/DiagramNode.js
+++ b/src/Diagram/DiagramNode/DiagramNode.js
@@ -22,7 +22,7 @@ const DiagramNode = (props) => {
   const { ref, onDragStart, onDrag } = useDrag({ throttleBy: 14 }); // get the drag n drop methods
   const dragStartPoint = useRef(coordinates); // keeps the drag start point in a persistent reference
 
-  if (!disableDrag) {
+  if (!disableDrag || disableDrag === 'x' || disableDrag === 'y') {
     // when drag starts, save the starting coordinates into the `dragStartPoint` ref
     onDragStart(() => {
       dragStartPoint.current = coordinates;
@@ -34,8 +34,8 @@ const DiagramNode = (props) => {
         event.stopImmediatePropagation();
         event.stopPropagation();
         const nextCoords = [
-          dragStartPoint.current[0] - info.offset[0],
-          dragStartPoint.current[1] - info.offset[1],
+          dragStartPoint.current[0] - (disableDrag === 'x' ? 0 : info.offset[0]),
+          dragStartPoint.current[1] - (disableDrag === 'y' ? 0 : info.offset[1]),
         ];
         onPositionChange(id, nextCoords);
       }
@@ -143,7 +143,7 @@ DiagramNode.propTypes = {
    * The possible className
    */
   className: PropTypes.string,
-  disableDrag: PropTypes.bool,
+  disableDrag: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
 };
 
 DiagramNode.defaultProps = {

--- a/src/Diagram/DiagramNode/getDiagramNodeStyle.js
+++ b/src/Diagram/DiagramNode/getDiagramNodeStyle.js
@@ -1,7 +1,16 @@
+const getDiagramNodeCursor = (disableDrag) => {
+  switch (disableDrag) {
+    case 'x': return 'ns-resize';
+    case 'y': return 'ew-resize';
+    case true: return undefined;
+    default: return 'move';
+  }
+};
+
 const getDiagramNodeStyle = (coordinates, disableDrag) => ({
   left: coordinates[0],
   top: coordinates[1],
-  cursor: disableDrag ? undefined : 'move',
+  cursor: getDiagramNodeCursor(disableDrag),
 });
 
 export default getDiagramNodeStyle;

--- a/src/Diagram/NodesCanvas/updateNodeCoordinates.js
+++ b/src/Diagram/NodesCanvas/updateNodeCoordinates.js
@@ -7,7 +7,7 @@ import findIndex from 'lodash.findindex';
 const updateNodeCoordinates = (nodeId, coordinates, nodes) => {
   const index = findIndex(nodes, ['id', nodeId]);
 
-  if (index > -1 && [false, 'x', 'y'].includes(nodes[index].disableDrag)) {
+  if (index > -1 && [undefined, 'x', 'y', false].includes(nodes[index].disableDrag)) {
     // eslint-disable-next-line no-param-reassign
     nodes[index].coordinates = coordinates;
   }

--- a/src/Diagram/NodesCanvas/updateNodeCoordinates.js
+++ b/src/Diagram/NodesCanvas/updateNodeCoordinates.js
@@ -7,7 +7,7 @@ import findIndex from 'lodash.findindex';
 const updateNodeCoordinates = (nodeId, coordinates, nodes) => {
   const index = findIndex(nodes, ['id', nodeId]);
 
-  if (index > -1 && !nodes[index].disableDrag) {
+  if (index > -1 && [false, 'x', 'y'].includes(nodes[index].disableDrag)) {
     // eslint-disable-next-line no-param-reassign
     nodes[index].coordinates = coordinates;
   }


### PR DESCRIPTION
## Description
This PR adds the option to force nodes to be confined to either the x or y axis when dragging. This is particularly useful when you need to keep a set of nodes in a list or row, but want their order to be changable. 

## Related Issue


## Motivation and Context
I'm creating a data import tool that will allow users to import CSV data from somewhere else that might not necessarily have the same headers, or that might need to transform their data somehow before it can be imported. I'm using beautiful-react-digrams to create a visual interface for defining the mapping of the source data fields to the destination data fields. The source and destination fields should be fixed on the left and right side of the Diagram Canvas respecitvely, but their vertical order can be changed.

## How Has This Been Tested?
`npm run test` are all passing. I tested in the one of the documentation examples and it seems to be working.

## Other Considerations
- Use of `ns-resize` and `ew-resize` cursors as opposed to the `move` cursor might be sort of subjective, especially since they technically don't represent resizing in this case.
- The `updateNodeCoordinates` could handle this functionality (leaving `DiagramNode` as it is), but I thought it made more sense for the node to keep track of it's own behavior.
- Adding additional options to `disableDrag` (`x` and `y`) seemed preferable to adding two more props: `disableDragX` and `disableDragY`, though that would make the boolean logic more clear.